### PR TITLE
feat: modern rate-limiter

### DIFF
--- a/github/util.go
+++ b/github/util.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -84,13 +85,7 @@ func validateValueFunc(values []string) schema.SchemaValidateDiagFunc {
 	return func(v any, k cty.Path) diag.Diagnostics {
 		errs := make([]error, 0)
 		value := v.(string)
-		valid := false
-		for _, role := range values {
-			if value == role {
-				valid = true
-				break
-			}
-		}
+		valid := slices.Contains(values, value)
 
 		if !valid {
 			errs = append(errs, fmt.Errorf("%s is an invalid value for argument %s", value, k))

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.25.0
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/go-jose/go-jose/v3 v3.0.4
+	github.com/gofri/go-github-ratelimit/v2 v2.0.2
 	github.com/golangci/golangci-lint/v2 v2.4.0
 	github.com/google/go-github/v74 v74.0.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
+	github.com/hashicorp/terraform-plugin-docs v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/shurcooL/githubv4 v0.0.0-20221126192849-0b5c4c7994eb
 	github.com/stretchr/testify v1.10.0
@@ -131,7 +133,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.23.0 // indirect
 	github.com/hashicorp/terraform-json v0.25.0 // indirect
-	github.com/hashicorp/terraform-plugin-docs v0.22.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.27.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUW
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/gofri/go-github-ratelimit/v2 v2.0.2 h1:gS8wAS1jTmlWGdTjAM7KIpsLjwY1S0S/gKK5hthfSXM=
+github.com/gofri/go-github-ratelimit/v2 v2.0.2/go.mod h1:YBQt4gTbdcbMjJFT05YFEaECwH78P5b0IwrnbLiHGdE=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -375,7 +377,6 @@ github.com/gostaticanalysis/testutil v0.5.0 h1:Dq4wT1DdTwTGCQQv3rl3IvD5Ld0E6HiY+
 github.com/gostaticanalysis/testutil v0.5.0/go.mod h1:OLQSbuM6zw2EvCcXTz1lVq5unyoNft372msDY0nY5Hs=
 github.com/hashicorp/cli v1.1.7 h1:/fZJ+hNdwfTSfsxMBa9WWMlfjUZbX8/LnUxgAd7lCVU=
 github.com/hashicorp/cli v1.1.7/go.mod h1:e6Mfpga9OCT1vqzFuoGZiiF/KaG9CbUfO5s3ghU3YgU=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -762,8 +763,6 @@ github.com/yuin/goldmark v1.7.7 h1:5m9rrB1sW3JUMToKFQfb+FGt1U7r57IHu5GrYrG2nqU=
 github.com/yuin/goldmark v1.7.7/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 github.com/yuin/goldmark-meta v1.1.0 h1:pWw+JLHGZe8Rk0EGsMVssiNb/AaPMHfSRszZeUeiOUc=
 github.com/yuin/goldmark-meta v1.1.0/go.mod h1:U4spWENafuA7Zyg+Lj5RqK/MF+ovMYtBvXi1lBb2VP0=
-github.com/zclconf/go-cty v1.16.2 h1:LAJSwc3v81IRBZyUVQDUdZ7hs3SYs9jv0eZJDWHD/70=
-github.com/zclconf/go-cty v1.16.2/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=
 github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -65,11 +65,15 @@ The following arguments are supported in the `provider` block:
   * `installation_id` - (Required) This is the ID of the GitHub App installation. It can sourced from the `GITHUB_APP_INSTALLATION_ID` environment variable.
   * `pem_file` - (Required) This is the contents of the GitHub App private key PEM file. It can also be sourced from the `GITHUB_APP_PEM_FILE` environment variable and may use `\n` instead of actual new lines.
 
-* `write_delay_ms` - (Optional) The number of milliseconds to sleep in between write operations in order to satisfy the GitHub API rate limits. Note that requests to the GraphQL API are implemented as `POST` requests under the hood, so this setting affects those calls as well. Defaults to 1000ms or 1 second if not provided.
+* `rate_limiter` - (Optional) The rate limiting strategy to use. `"modern"` uses go-github-ratelimit for automatic GitHub API rate limit handling. `"legacy"` uses the provider's built-in rate limiting with configurable delays. When using `"modern"`, the `read_delay_ms`, `write_delay_ms`, and `parallel_requests` settings are ignored. Defaults to `"modern"`.
+
+* `write_delay_ms` - (Optional) The number of milliseconds to sleep in between write operations in order to satisfy the GitHub API rate limits. Note that requests to the GraphQL API are implemented as `POST` requests under the hood, so this setting affects those calls as well. Defaults to 1000ms or 1 second if not provided. This setting is ignored when `rate_limiter` is `"modern"`.
 
 * `retry_delay_ms` - (Optional) Amount of time in milliseconds to sleep in between requests to GitHub API after an error response. Defaults to 1000ms or 1 second if not provided, the max_retries must be set to greater than zero.
 
-* `read_delay_ms` - (Optional) The number of milliseconds to sleep in between non-write operations in order to satisfy the GitHub API rate limits. Defaults to 0ms.
+* `read_delay_ms` - (Optional) The number of milliseconds to sleep in between non-write operations in order to satisfy the GitHub API rate limits. Defaults to 0ms. This setting is ignored when `rate_limiter` is `"modern"`.
+
+* `parallel_requests` - (Optional) Allow the provider to make parallel API calls to GitHub. You may want to set it to `true` when you have a private GitHub Enterprise without strict rate limits. Although, it is not possible to enable this setting on github.com because we enforce the respect of github.com's best practices to avoid hitting abuse rate limits. Defaults to `false` if not set. This setting is ignored when `rate_limiter` is `"modern"`.
 
 * `retryable_errors` - (Optional) "Allow the provider to retry after receiving an error status code, the max_retries should be set for this to work. Defaults to [500, 502, 503, 504]
 


### PR DESCRIPTION
This pull request introduces a new, modern rate limiting strategy to the GitHub Terraform provider, allowing users to choose between the existing "legacy" rate limiter and a new "modern" mode based on the `go-github-ratelimit` library. The documentation and provider configuration are updated to reflect this new option, and the codebase is refactored to support both strategies. Additionally, a minor code simplification is made in a utility function.

**Provider rate limiting improvements:**

* Added a new `rate_limiter` configuration option to the provider, allowing users to select between `"modern"` (using `go-github-ratelimit` for automatic GitHub API rate limit handling) and `"legacy"` (the existing provider-side implementation). When `"modern"` is selected, the `read_delay_ms`, `write_delay_ms`, and `parallel_requests` settings are ignored. `"modern"` is now the default. [[1]](diffhunk://#diff-cad3f34e54de360074c788e87373797270604447021bd5abaeca869c67cdf9afR96-R108) [[2]](diffhunk://#diff-cad3f34e54de360074c788e87373797270604447021bd5abaeca869c67cdf9afR317-R320) [[3]](diffhunk://#diff-cad3f34e54de360074c788e87373797270604447021bd5abaeca869c67cdf9afR448-R450) [[4]](diffhunk://#diff-cad3f34e54de360074c788e87373797270604447021bd5abaeca869c67cdf9afR462) [[5]](diffhunk://#diff-062b7a475c9ddd7765fd96c620a3f7854307a4b68c0ff57db24b9d912b5bcec9R30) [[6]](diffhunk://#diff-062b7a475c9ddd7765fd96c620a3f7854307a4b68c0ff57db24b9d912b5bcec9L44-R46) [[7]](diffhunk://#diff-062b7a475c9ddd7765fd96c620a3f7854307a4b68c0ff57db24b9d912b5bcec9R63-R74) [[8]](diffhunk://#diff-062b7a475c9ddd7765fd96c620a3f7854307a4b68c0ff57db24b9d912b5bcec9L69-R86) [[9]](diffhunk://#diff-062b7a475c9ddd7765fd96c620a3f7854307a4b68c0ff57db24b9d912b5bcec9L78-R98) [[10]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R8-R13)
* Updated documentation (`docs/index.md` and `templates/index.md.tmpl`) to describe the new `rate_limiter` option and clarify the behavior of related settings when using the modern rate limiter. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L117-R111) [[2]](diffhunk://#diff-2787aac6ad1510c9157d238b7b366aa4a6abdeba2429c28affad380e0bd3df26L68-R76)

**Dependency and code maintenance:**

* Added `github.com/gofri/go-github-ratelimit/v2` as a dependency in `go.mod` for the new rate limiting functionality.
* Minor code cleanup: replaced a manual loop with `slices.Contains` in the `validateValueFunc` utility function for improved readability and efficiency. [[1]](diffhunk://#diff-6cd2f7de74a70fa22b2de2de01186563b7c16fee7606e9bffdef60048dfb1b31R11) [[2]](diffhunk://#diff-6cd2f7de74a70fa22b2de2de01186563b7c16fee7606e9bffdef60048dfb1b31L87-R88)

**Documentation cleanup:**

* Removed outdated Terraform 0.12 example from the documentation to reduce confusion.